### PR TITLE
Fix build matrix and name in cs version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: c
 matrix:
+  include:
   - os: osx
     compiler: gcc
     env: PATH=./racket/bin:$PATH
@@ -24,15 +25,24 @@ matrix:
     compiler: gcc
     env: PATH=./racket/bin:$PATH RACKET_CONFIGURE_ARGS="--disable-jit --disable-places
       --disable-futures --disable-extflonum"
-  allow-failures:
-    - os: linux
-      compiler: clang
-      env: PATH=./racket/bin:$PATH TARGET="cs"
+  - os: linux
+    compiler: clang
+    env: PATH=./racket/bin:$PATH TARGET="cs"
+  allow_failures:
+  - os: linux
+    compiler: clang
+    env: PATH=./racket/bin:$PATH TARGET="cs"
 before_script:
 - git config --global user.email "travis-test@racket-lang.org"
 - git config --global user.name "Travis Tester"
 script:
-- make $TARGET CPUS="2" PKGS="racket-test db-test unstable-flonum-lib net-test" CONFIGURE_ARGS_qq="$RACKET_CONFIGURE_ARGS"
+- make $TARGET  \
+       CPUS="2"  \
+       PKGS="racket-test db-test unstable-flonum-lib net-test"  \
+       CONFIGURE_ARGS_qq="$RACKET_CONFIGURE_ARGS"  \
+       RACKETCS_SUFFIX="$RACKETCS_SUFFIX"
+- which racket
+- racket -v
 - raco test -l tests/racket/test
 - racket -l tests/racket/contract/all
 - raco test -l tests/json/json


### PR DESCRIPTION
This is my preferred version. I couldn't write in your branch, so here is a PR. Related to https://github.com/racket/racket/pull/2266

With this script the "default" value of `RACKETCS_SUFFIX` is effectively `""`
instead of `"cs"` as in the make file.

This is a minor incompatibility/unexpected behavior that will get eventually
solved when the real default changes to `""`.