### PR TITLE
Reject non-linear match patterns with mismatched ellipsis depth

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/match.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/match.scrbl
@@ -126,6 +126,16 @@ In more detail, patterns match as follows:
        @racketidfont{not} sub-patterns are independent. The binding for @racket[_id] is
        not available in other parts of the same pattern.
 
+       When an @racket[_id] is used both under a @racketidfont{...} splicing
+       operator and in a position not under the same @racketidfont{...}
+       within the same pattern, each individual element matched under
+       @racketidfont{...} is checked for equality against the other occurrence.
+       In the body, the @racket[_id] that is under @racketidfont{...}
+       is bound to a list of matches, and the @racket[_id] not under
+       @racketidfont{...} is bound to the single matching value; which binding
+       is visible in the body depends on the order of evaluation.
+       See @secref["match-nonlinear-ellipsis"] for details and examples.
+
        @examples[
        #:eval match-eval
        (match '(1 2 3)
@@ -942,6 +952,96 @@ sub-expression to be used as the source for all syntax errors within the form.
 For example, @racket[match-lambda] expands to @racket[match/derived] so that
 errors in the body of the form are reported in terms of @racket[match-lambda]
 instead of @racket[match].}
+
+@; ----------------------------------------------------------------------
+
+@section[#:tag "match-nonlinear-ellipsis"]{Non-linear Patterns and Ellipses}
+
+When the same identifier is used multiple times within a pattern
+(a @deftech{non-linear pattern}), each occurrence must match the same
+value according to @racket[(match-equality-test)].
+
+Non-linear patterns can interact with @racketidfont{...} (ellipsis)
+splicing operators in several ways:
+
+@subsection{Both occurrences under the same @racketidfont{...}}
+
+When both occurrences of an identifier are under the same
+@racketidfont{...}, each repetition of the pattern checks equality
+between the occurrences within that repetition. The identifier
+binds to a list of the matched values.
+
+@examples[
+#:eval match-eval
+(code:comment "each pair must have equal elements")
+(match '((1 1) (2 2) (3 3))
+  [(list (list a a) ...) a]
+  [_ 'no])
+(code:comment "second pair doesn't match: 2 != 3")
+(match '((1 1) (2 3) (3 3))
+  [(list (list a a) ...) a]
+  [_ 'no])
+]
+
+@subsection{First occurrence before @racketidfont{...}, second under @racketidfont{...}}
+
+When an identifier first appears in a position not under
+@racketidfont{...}, and then appears under @racketidfont{...}, each
+element matched under @racketidfont{...} is checked for equality against
+the first occurrence.
+
+@examples[
+#:eval match-eval
+(code:comment "t matches 1, then each element under ... must equal 1")
+(match '(1 1 1 1)
+  [(cons t (list t ...)) t]
+  [_ 'no])
+(code:comment "3 does not equal 1")
+(match '(1 2 3)
+  [(cons t (list t ...)) t]
+  [_ 'no])
+(code:comment "the inner x must equal the outer x for each pair")
+(match '((1 . 2) (1 . 3) (1 . 4))
+  [(cons (cons x _) (list (cons x _) ...)) x]
+  [_ 'no])
+(code:comment "second pair has 5, not 1")
+(match '((1 . 2) (5 . 3) (1 . 4))
+  [(cons (cons x _) (list (cons x _) ...)) x]
+  [_ 'no])
+]
+
+@subsection{First occurrence under @racketidfont{...}, second after @racketidfont{...}}
+
+When an identifier first appears under @racketidfont{...} and then
+appears after the @racketidfont{...} in the same @racketidfont{list}
+pattern, the identifier under @racketidfont{...} collects values into a
+list. After the @racketidfont{...}, the second occurrence must match a
+value equal to the collected list.
+
+@examples[
+#:eval match-eval
+(code:comment "x collects to (1 1 1), tail x must match (1 1 1)")
+(match '(1 1 1 (1 1 1))
+  [(list x ... x) x]
+  [_ 'no])
+(code:comment "x collects to (1 1), tail x is 99 != (1 1)")
+(match '(1 1 99)
+  [(list x ... x) x]
+  [_ 'no])
+(code:comment "x collects to (1 1) from heads, tail x matches (1 1)")
+(match '((1 a) (1 b) (1 1))
+  [(list (list x _) ... x) x]
+  [_ 'no])
+(code:comment "x collects to (1 1), tail x is 99 != (1 1)")
+(match '((1 a) (1 b) 99)
+  [(list (list x _) ... x) x]
+  [_ 'no])
+]
+
+@history[#:changed "8.15.0.4" @elem{Added support for non-linear
+patterns where an identifier appears both under @racketidfont{...} and after
+it in the same @racketidfont{list} pattern, and fixed a crash when an
+identifier appeared both before and under @racketidfont{...}.}]
 
 @; ----------------------------------------------------------------------
 

--- a/pkgs/racket-doc/scribblings/reference/match.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/match.scrbl
@@ -126,14 +126,9 @@ In more detail, patterns match as follows:
        @racketidfont{not} sub-patterns are independent. The binding for @racket[_id] is
        not available in other parts of the same pattern.
 
-       When an @racket[_id] is used both under a @racketidfont{...} splicing
-       operator and in a position not under the same @racketidfont{...}
-       within the same pattern, each individual element matched under
-       @racketidfont{...} is checked for equality against the other occurrence.
-       In the body, the @racket[_id] that is under @racketidfont{...}
-       is bound to a list of matches, and the @racket[_id] not under
-       @racketidfont{...} is bound to the single matching value; which binding
-       is visible in the body depends on the order of evaluation.
+       If @racket[_id] is used multiple times, but the first use is in
+       the scope of a @racketidfont{...} pattern that doesn't encompass all
+       uses, a syntax error is raised.
        See @secref["match-nonlinear-ellipsis"] for details and examples.
 
        @examples[
@@ -1010,38 +1005,24 @@ the first occurrence.
   [_ 'no])
 ]
 
-@subsection{First occurrence under @racketidfont{...}, second after @racketidfont{...}}
+@subsection{First occurrence under @racketidfont{...}, second not under the same @racketidfont{...}}
 
-When an identifier first appears under @racketidfont{...} and then
-appears after the @racketidfont{...} in the same @racketidfont{list}
-pattern, the identifier under @racketidfont{...} collects values into a
-list. After the @racketidfont{...}, the second occurrence must match a
-value equal to the collected list.
+If an identifier's first use is in the scope of a @racketidfont{...}
+pattern that does not encompass all other uses of that identifier, a
+syntax error is raised. This includes patterns like
+@racket[(list a ... a)], where @racket[a] is first bound under
+@racketidfont{...} and then used after it.
 
 @examples[
 #:eval match-eval
-(code:comment "x collects to (1 1 1), tail x must match (1 1 1)")
-(match '(1 1 1 (1 1 1))
-  [(list x ... x) x]
-  [_ 'no])
-(code:comment "x collects to (1 1), tail x is 99 != (1 1)")
-(match '(1 1 99)
-  [(list x ... x) x]
-  [_ 'no])
-(code:comment "x collects to (1 1) from heads, tail x matches (1 1)")
-(match '((1 a) (1 b) (1 1))
-  [(list (list x _) ... x) x]
-  [_ 'no])
-(code:comment "x collects to (1 1), tail x is 99 != (1 1)")
-(match '((1 a) (1 b) 99)
-  [(list (list x _) ... x) x]
-  [_ 'no])
+(eval:error (match '(1 2 3 4) [(list a ... a) a]))
+(eval:error (match '((1 2) 3) [(list (list a ...) a) a]))
 ]
 
-@history[#:changed "8.15.0.4" @elem{Added support for non-linear
-patterns where an identifier appears both under @racketidfont{...} and after
-it in the same @racketidfont{list} pattern, and fixed a crash when an
-identifier appeared both before and under @racketidfont{...}.}]
+@history[#:changed "8.15.0.4" @elem{Fixed a crash when an identifier
+appeared both before and under @racketidfont{...}, and changed
+patterns where an identifier first appears under @racketidfont{...}
+and later outside it to raise a syntax error.}]
 
 @; ----------------------------------------------------------------------
 

--- a/pkgs/racket-test/tests/match/main.rkt
+++ b/pkgs/racket-test/tests/match/main.rkt
@@ -254,7 +254,111 @@
                     [_ #f]))
      (check-equal? (match '((1 1 2 3) (2 1 2 3) (3 1 2 3))
                      [(list (cons a (list pre ... a post ...)) ...) (list a pre post)])
-                   '((1 2 3) (() (1) (1 2)) ((2 3) (3) ()))))))
+                   '((1 2 3) (() (1) (1 2)) ((2 3) (3) ()))))
+
+   ;; Regression tests for issues #5442, #2152, #1386
+   ;; Non-linear patterns across ... boundaries (variable bound under
+   ;; ... and used after ... in the same pattern)
+
+   (test-case "Non-linear across ... (issue #5442)"
+     ;; Original report: (cons (cons x _) (list (cons x _) ...))
+     ;; Previously raised "unbound identifier" error
+     (check-equal? (match '((1 . 2) (1 . 3) (1 . 4))
+                     [(cons (cons x _) (list (cons x _) ...)) x]
+                     [_ 'no])
+                   1)
+     ;; Should fail when values don't match
+     (check-equal? (match '((1 . 2) (3 . 4) (1 . 5))
+                     [(cons (cons x _) (list (cons x _) ...)) x]
+                     [_ 'no])
+                   'no))
+
+   (test-case "Non-linear across ... (issue #2152)"
+     ;; Minimal example from issue: `(,t ,t ...)
+     (check-equal? (match '(1 1 1)
+                     [`(,t ,t ...) t]
+                     [_ 'no])
+                   1)
+     (check-equal? (match '(1 2 3)
+                     [`(,t ,t ...) t]
+                     [_ 'no])
+                   'no))
+
+   (test-case "Non-linear across ... with cons"
+     ;; (cons x (list x ...)) — x first, then x under ...
+     (check-equal? (match '(1 1 1)
+                     [(cons t (list t ...)) t]
+                     [_ 'no])
+                   1)
+     (check-equal? (match '(1 2 3)
+                     [(cons t (list t ...)) t]
+                     [_ 'no])
+                   'no))
+
+   (test-case "Variable bound under ..., used after ..."
+     ;; (list (list x _) ... x): x collects under ..., then x after
+     ;; x collects to (1 1 1), tail x matches 99 — should fail
+     (check-equal? (match '((1 a) (1 b) (1 c) 99)
+                     [(list (list x _) ... x) (list 'match x)]
+                     [_ 'no])
+                   'no)
+     ;; x collects to (1 1), tail x matches (1 1) — should succeed
+     (check-equal? (match '((1 a) (1 b) (1 1))
+                     [(list (list x _) ... x) x]
+                     [_ 'no])
+                   '(1 1)))
+
+   (test-case "list x ... x"
+     ;; x collects to (1 1 1), tail x matches (1 1 1) — should succeed
+     (check-equal? (match '(1 1 1 (1 1 1))
+                     [(list x ... x) x]
+                     [_ 'no])
+                   '(1 1 1))
+     ;; tail x is 99, doesn't match collected (1 1)
+     (check-equal? (match '(1 1 99)
+                     [(list x ... x) x]
+                     [_ 'no])
+                   'no))
+
+   (test-case "Non-linear across ... with vectors"
+     ;; (list (vector x y) ... x): x under ..., then x after
+     (check-equal? (match '(#(1 a) #(1 b) (1 1))
+                     [(list (vector x y) ... x) (list x y)]
+                     [_ 'no])
+                   '((1 1) (a b)))
+     (check-equal? (match '(#(1 a) #(2 b) (1 2))
+                     [(list (vector x y) ... x) (list x y)]
+                     [_ 'no])
+                   '((1 2) (a b)))
+     ;; Should fail: collected x = (1 2), tail = 99
+     (check-equal? (match '(#(1 a) #(2 b) 99)
+                     [(list (vector x y) ... x) (list x y)]
+                     [_ 'no])
+                   'no))
+
+   (test-case "Non-linear under ... still works"
+     ;; Both occurrences of a are under the same ...
+     (check-equal? (match '((1 1) (2 2) (3 3))
+                     [(list (list a a) ...) a]
+                     [_ 'no])
+                   '(1 2 3))
+     (check-equal? (match '((1 2) (2 2) (3 3))
+                     [(list (list a a) ...) a]
+                     [_ 'no])
+                   'no))
+
+   (test-case "Empty ... with non-linear"
+     ;; Empty list: x collects to (), tail x matches ()
+     (check-equal? (match '(())
+                     [(list x ... x) x]
+                     [_ 'no])
+                   '())
+     ;; (cons t (list t ...)) with single element — 0 iterations,
+     ;; each element (vacuously) equals t=1, body sees t=1
+     (check-equal? (match '(1)
+                     [(cons t (list t ...)) t]
+                     [_ 'no])
+                   1))))
 
 
 (define doc-tests

--- a/pkgs/racket-test/tests/match/main.rkt
+++ b/pkgs/racket-test/tests/match/main.rkt
@@ -295,47 +295,6 @@
                      [_ 'no])
                    'no))
 
-   (test-case "Variable bound under ..., used after ..."
-     ;; (list (list x _) ... x): x collects under ..., then x after
-     ;; x collects to (1 1 1), tail x matches 99 — should fail
-     (check-equal? (match '((1 a) (1 b) (1 c) 99)
-                     [(list (list x _) ... x) (list 'match x)]
-                     [_ 'no])
-                   'no)
-     ;; x collects to (1 1), tail x matches (1 1) — should succeed
-     (check-equal? (match '((1 a) (1 b) (1 1))
-                     [(list (list x _) ... x) x]
-                     [_ 'no])
-                   '(1 1)))
-
-   (test-case "list x ... x"
-     ;; x collects to (1 1 1), tail x matches (1 1 1) — should succeed
-     (check-equal? (match '(1 1 1 (1 1 1))
-                     [(list x ... x) x]
-                     [_ 'no])
-                   '(1 1 1))
-     ;; tail x is 99, doesn't match collected (1 1)
-     (check-equal? (match '(1 1 99)
-                     [(list x ... x) x]
-                     [_ 'no])
-                   'no))
-
-   (test-case "Non-linear across ... with vectors"
-     ;; (list (vector x y) ... x): x under ..., then x after
-     (check-equal? (match '(#(1 a) #(1 b) (1 1))
-                     [(list (vector x y) ... x) (list x y)]
-                     [_ 'no])
-                   '((1 1) (a b)))
-     (check-equal? (match '(#(1 a) #(2 b) (1 2))
-                     [(list (vector x y) ... x) (list x y)]
-                     [_ 'no])
-                   '((1 2) (a b)))
-     ;; Should fail: collected x = (1 2), tail = 99
-     (check-equal? (match '(#(1 a) #(2 b) 99)
-                     [(list (vector x y) ... x) (list x y)]
-                     [_ 'no])
-                   'no))
-
    (test-case "Non-linear under ... still works"
      ;; Both occurrences of a are under the same ...
      (check-equal? (match '((1 1) (2 2) (3 3))
@@ -348,17 +307,105 @@
                    'no))
 
    (test-case "Empty ... with non-linear"
-     ;; Empty list: x collects to (), tail x matches ()
-     (check-equal? (match '(())
-                     [(list x ... x) x]
-                     [_ 'no])
-                   '())
      ;; (cons t (list t ...)) with single element — 0 iterations,
      ;; each element (vacuously) equals t=1, body sees t=1
      (check-equal? (match '(1)
                      [(cons t (list t ...)) t]
                      [_ 'no])
-                   1))))
+                   1))
+
+   (test-case "Non-linear with list-no-order across ..."
+     ;; (cons a (list-no-order a rst ...)) — a at depth 0, then under ...
+     (check-equal? (match '(2 1 2 3)
+                     [(cons a (list-no-order a rst ...)) (list a rst)]
+                     [_ 'no])
+                   '(2 (1 3))))
+
+   (test-case "Non-linear x x ... valid direction"
+     ;; (list x x ...) — first x at depth 0, second under ...
+     (check-equal? (match '(1 1 1)
+                     [(list x x ...) x]
+                     [_ 'no])
+                   1)
+     (check-equal? (match '(1 2 3)
+                     [(list x x ...) x]
+                     [_ 'no])
+                   'no))
+
+   ;; Patterns where the first use of an identifier is under ...
+   ;; and a later use is not under the same ... should be syntax errors.
+   ;; We use ___ (alias for ...) to avoid template ellipsis issues in #'(...).
+   (test-case "Syntax error: list a ... a"
+     (check-exn exn:fail:syntax?
+                (lambda ()
+                  (expand #'(match '(1 2 3 4) [(list a ___ a) a])))))
+
+   (test-case "Syntax error: list (list a ...) a"
+     (check-exn exn:fail:syntax?
+                (lambda ()
+                  (expand #'(match '((1 2) 3) [(list (list a ___) a) a])))))
+
+   (test-case "Syntax error: list (list a ... _) a"
+     (check-exn exn:fail:syntax?
+                (lambda ()
+                  (expand #'(match '((1 2 3) 4) [(list (list a ___ _) a) a])))))
+
+   (test-case "Syntax error: list (list x ...) (list x ...)"
+     (check-exn exn:fail:syntax?
+                (lambda ()
+                  (expand #'(match '((1 2) (1 2)) [(list (list x ___) (list x ___)) x])))))
+
+   (test-case "Syntax error: list (list x _) ... x"
+     (check-exn exn:fail:syntax?
+                (lambda ()
+                  (expand #'(match '((1 a) (1 b) 99) [(list (list x _) ___ x) x])))))
+
+   ;; ..k variants
+   (test-case "Syntax error: list a ..2 a"
+     (check-exn exn:fail:syntax?
+                (lambda ()
+                  (expand #'(match '(1 2 3) [(list a ..2 a) a])))))
+
+   (test-case "Syntax error: list (list a ..3) a"
+     (check-exn exn:fail:syntax?
+                (lambda ()
+                  (expand #'(match '((1 2 3) 4) [(list (list a ..3) a) a])))))
+
+   ;; list-rest
+   (test-case "Syntax error: list-rest with mismatched depth"
+     (check-exn exn:fail:syntax?
+                (lambda ()
+                  (expand #'(match '((1 2) 3) [(list-rest (list a ___) a) a])))))
+
+   ;; quasipatterns
+   (test-case "Syntax error: quasipattern ,a ... ,a"
+     (check-exn exn:fail:syntax?
+                (lambda ()
+                  (expand #'(match '(1 2 3 4) [`(,a ___ ,a) a])))))
+
+   ;; Valid: list-rest with correct direction
+   ;; (list-rest a (list a ___)) matches (cons a (list a ___))
+   ;; i.e., first element is a, rest is a list of a's
+   (test-case "Non-linear list-rest valid direction"
+     (check-equal? (match '(1 1 1)
+                     [(list-rest a (list a ___)) a]
+                     [_ 'no])
+                   1)
+     (check-equal? (match '(1 2 3)
+                     [(list-rest a (list a ___)) a]
+                     [_ 'no])
+                   'no))
+
+   ;; Valid: quasipattern with correct direction
+   (test-case "Non-linear quasipattern valid direction"
+     (check-equal? (match '(1 1 1)
+                     [`(,a ,a ___) a]
+                     [_ 'no])
+                   1)
+     (check-equal? (match '(1 2 3)
+                     [`(,a ,a ___) a]
+                     [_ 'no])
+                   'no))))
 
 
 (define doc-tests

--- a/racket/collects/racket/match/compiler.rkt
+++ b/racket/collects/racket/match/compiler.rkt
@@ -14,6 +14,12 @@
 ;; should we reorder stuff?
 (define can-reorder? (make-parameter #t #f 'can-reorder?))
 
+;; When PLT_MATCH_STRICT_ELLIPSIS is set, reject ALL non-linear
+;; patterns with differing ellipsis depth, including the case where
+;; the first binding is at a lower depth than a later use under ...
+;; (e.g., (cons x (list x ...)) would be rejected).
+(define strict-ellipsis? (and (getenv "PLT_MATCH_STRICT_ELLIPSIS") #t))
+
 ;; for non-linear patterns
 (define vars-seen (make-parameter null #f 'vars-seen))
 
@@ -225,16 +231,13 @@
                                          (fail))
                                    (Row-unmatch row)
                                    seen))
-                       ;; id is #f: variable was bound under ... (in heads-seen)
-                      ;; and we're still inside the GSeq loop. Bind the variable
-                      ;; without an equality check; the check will happen after
-                      ;; the loop via heads-seen-final in tail-rhs.
-                      (let ([v* (free-identifier-mapping-get
-                                 (current-renaming) v (lambda () v))])
-                        (make-Row ps
-                                  #`(let ([#,v* #,x]) #,(Row-rhs row))
-                                  (Row-unmatch row)
-                                  (cons (cons v x) (Row-vars-seen row))))))]
+                       ;; id is #f: variable was first bound under ... at a
+                      ;; higher depth. This is a non-linear pattern with
+                      ;; mismatched ellipsis depths, which is not supported.
+                      (raise-syntax-error
+                       'match
+                       "non-linear pattern used in `match` with ..."
+                       v)))]
                 ;; otherwise, bind the matched variable to x, and add it to the
                 ;; list of vars we've seen
                 [else (let ([v* (free-identifier-mapping-get
@@ -408,12 +411,15 @@
        (define v (Var-v (caar (GSeq-headss first))))
        (define v* (free-identifier-mapping-get
                    (current-renaming) v (lambda () v)))
+       ;; Mark v with #f in vars-seen (like heads-seen does in the
+       ;; full GSeq path) so that if v appears again in rest-pats,
+       ;; it triggers a syntax error for mismatched ellipsis depth.
        (with-syntax ([body (compile**
                             xs
                             (list (make-Row rest-pats
                                             (Row-rhs row)
                                             (Row-unmatch row)
-                                            (cons (cons v x) (Row-vars-seen row))))
+                                            (cons (cons v #f) (Row-vars-seen row))))
                             esc)])
          #`(if (list? #,x)
                (let ([#,v* #,x]) body)
@@ -444,38 +450,20 @@
             [heads-seen
              (map (lambda (x) (cons x #f))
                   (apply append (map bound-vars heads)))]
-            ;; heads-seen-final maps head variables to their bound
-            ;; identifiers for use after the loop (in tail-rhs), where
-            ;; variables have been collected into their final values.
-            ;; Unlike heads-seen (which uses #f to suppress equality
-            ;; checks inside the loop), this enables proper non-linear
-            ;; matching for variables bound under ... and used after.
-            [heads-seen-final
-             (map (lambda (x) (cons x x))
-                  (apply append head-idss))]
-            [tail-ids (bound-vars tail)]
+            [_ (when strict-ellipsis?
+                 (for* ([hids (in-list head-idss)]
+                        [hv (in-list hids)])
+                   (when (for/or ([e (in-list (Row-vars-seen (car block)))])
+                           (bound-identifier=? hv (car e)))
+                     (raise-syntax-error
+                      'match
+                      "non-linear pattern used in `match` with ..."
+                      hv))))]
             [tail-seen
              (map (lambda (x) (cons x x))
-                  tail-ids)]
+                  (bound-vars tail))]
             [hid-argss (map generate-temporaries head-idss)]
             [head-idss* (map generate-temporaries head-idss)]
-            ;; Variables that appear in both head and tail patterns.
-            ;; For each such variable, we need an equality check in
-            ;; tail-rhs between the tail-matched value (held in the
-            ;; renamed head-id*) and the head-collected value (bound
-            ;; to the original head-id by the let in tail-rhs).
-            ;; shared-head-tail is a list of (head-id . head-id*) pairs.
-            [shared-head-tail
-             (let ([all-head-ids (apply append head-idss)]
-                   [all-head-ids* (apply append head-idss*)])
-               (for/list ([tid (in-list tail-ids)]
-                          #:when (for/or ([hid (in-list all-head-ids)])
-                                   (bound-identifier=? tid hid)))
-                 ;; find the corresponding head-id and head-id*
-                 (for/or ([hid (in-list all-head-ids)]
-                          [hid* (in-list all-head-ids*)])
-                   (and (bound-identifier=? tid hid)
-                        (cons hid hid*)))))]
             [hid-args (apply append hid-argss)]
             [reps (generate-temporaries (for/list ([head heads]) 'rep))])
        (with-syntax ([x xvar]
@@ -511,30 +499,16 @@
                                 [else
                                  (let ([hid hid-rhs] ... ...
                                        [fail-tail fail])
-                                   #,(let ([rest-body
-                                            (compile**
-                                             (cdr vars)
-                                             (list (make-Row rest-pats k
-                                                             (Row-unmatch (car block))
-                                                             (append
-                                                              heads-seen-final
-                                                              tail-seen
-                                                              (Row-vars-seen
-                                                               (car block)))))
-                                             #'fail-tail)])
-                                       ;; Wrap rest-body with equality checks for
-                                       ;; variables shared between head and tail.
-                                       ;; After the let above, hid = collected value.
-                                       ;; hid* (renamed) = tail-matched value.
-                                       (let ([body
-                                              (for/fold ([body rest-body])
-                                                        ([pair (in-list shared-head-tail)])
-                                                (let ([orig-id (car pair)]
-                                                      [renamed-id (cdr pair)])
-                                                  #`(if ((match-equality-test) #,renamed-id #,orig-id)
-                                                         #,body
-                                                         (fail-tail))))])
-                                         body)))])])
+                                   #,(compile**
+                                      (cdr vars)
+                                      (list (make-Row rest-pats k
+                                                      (Row-unmatch (car block))
+                                                      (append
+                                                       heads-seen
+                                                       tail-seen
+                                                       (Row-vars-seen
+                                                        (car block)))))
+                                      #'fail-tail))])])
            (parameterize ([current-renaming
                            (for/fold ([ht (copy-mapping (current-renaming))])
                                ([id (apply append head-idss)]

--- a/racket/collects/racket/match/compiler.rkt
+++ b/racket/collects/racket/match/compiler.rkt
@@ -217,21 +217,24 @@
                  =>
                  (lambda (id)
                    (if (identifier? id)
-                       (make-Row ps
-                                 #`(if ((match-equality-test) #,x #,id)
-                                       #,(Row-rhs row)
-                                       (fail))
-                                 (Row-unmatch row)
-                                 seen)
-                       (begin
-                         (log-error "non-linear pattern used in `match` with ... at ~a and ~a"
-                                    (car id) (cadr id)) 
-                         (let ([v* (free-identifier-mapping-get
-                                    (current-renaming) v (lambda () v))])
-                           (make-Row ps
-                                     #`(let ([#,v* #,x]) #,(Row-rhs row))
-                                     (Row-unmatch row)
-                                     (cons (cons v x) (Row-vars-seen row)))))))]
+                       (let ([v* (free-identifier-mapping-get
+                                  (current-renaming) v (lambda () v))])
+                         (make-Row ps
+                                   #`(if ((match-equality-test) #,x #,id)
+                                         (let ([#,v* #,x]) #,(Row-rhs row))
+                                         (fail))
+                                   (Row-unmatch row)
+                                   seen))
+                       ;; id is #f: variable was bound under ... (in heads-seen)
+                      ;; and we're still inside the GSeq loop. Bind the variable
+                      ;; without an equality check; the check will happen after
+                      ;; the loop via heads-seen-final in tail-rhs.
+                      (let ([v* (free-identifier-mapping-get
+                                 (current-renaming) v (lambda () v))])
+                        (make-Row ps
+                                  #`(let ([#,v* #,x]) #,(Row-rhs row))
+                                  (Row-unmatch row)
+                                  (cons (cons v x) (Row-vars-seen row))))))]
                 ;; otherwise, bind the matched variable to x, and add it to the
                 ;; list of vars we've seen
                 [else (let ([v* (free-identifier-mapping-get
@@ -378,6 +381,44 @@
     [(GSeq? first)
      (unless (null? (cdr block))
        (error 'compile-one "GSeq block with multiple rows: ~a" block))
+     ;; Optimization: (list x ...) where x is a fresh variable can be
+     ;; compiled as (and (? list?) x) instead of a full GSeq loop,
+     ;; since binding x to the whole list is equivalent to collecting
+     ;; each element. But this is only valid when x is NOT a repeated
+     ;; (non-linear) variable, because non-linear matching needs to
+     ;; compare each element individually.
+     (define (simple-var-gseq?)
+       (and (= (length (GSeq-headss first)) 1)
+            (= (length (car (GSeq-headss first))) 1)
+            (Var? (caar (GSeq-headss first)))
+            (not (Dummy? (caar (GSeq-headss first))))
+            (Null? (GSeq-tail first))
+            (not (car (GSeq-mins first)))
+            (not (car (GSeq-maxs first)))
+            (not (car (GSeq-onces? first)))
+            (not (GSeq-mutable? first))
+            (let ([v (Var-v (caar (GSeq-headss first)))])
+              (not (for/or ([e (in-list (Row-vars-seen (car block)))])
+                     (bound-identifier=? v (car e)))))))
+     (cond
+      [(simple-var-gseq?)
+       ;; Compile as (and (? list?) x) — just check list? and bind
+       (define-values (_p rest-pats) (Row-split-pats (car block)))
+       (define row (car block))
+       (define v (Var-v (caar (GSeq-headss first))))
+       (define v* (free-identifier-mapping-get
+                   (current-renaming) v (lambda () v)))
+       (with-syntax ([body (compile**
+                            xs
+                            (list (make-Row rest-pats
+                                            (Row-rhs row)
+                                            (Row-unmatch row)
+                                            (cons (cons v x) (Row-vars-seen row))))
+                            esc)])
+         #`(if (list? #,x)
+               (let ([#,v* #,x]) body)
+               (#,esc)))]
+      [else
      (let* ([headss (GSeq-headss first)]
             [mins (GSeq-mins first)]
             [maxs (GSeq-maxs first)]
@@ -403,11 +444,38 @@
             [heads-seen
              (map (lambda (x) (cons x #f))
                   (apply append (map bound-vars heads)))]
+            ;; heads-seen-final maps head variables to their bound
+            ;; identifiers for use after the loop (in tail-rhs), where
+            ;; variables have been collected into their final values.
+            ;; Unlike heads-seen (which uses #f to suppress equality
+            ;; checks inside the loop), this enables proper non-linear
+            ;; matching for variables bound under ... and used after.
+            [heads-seen-final
+             (map (lambda (x) (cons x x))
+                  (apply append head-idss))]
+            [tail-ids (bound-vars tail)]
             [tail-seen
              (map (lambda (x) (cons x x))
-                  (bound-vars tail))]
+                  tail-ids)]
             [hid-argss (map generate-temporaries head-idss)]
             [head-idss* (map generate-temporaries head-idss)]
+            ;; Variables that appear in both head and tail patterns.
+            ;; For each such variable, we need an equality check in
+            ;; tail-rhs between the tail-matched value (held in the
+            ;; renamed head-id*) and the head-collected value (bound
+            ;; to the original head-id by the let in tail-rhs).
+            ;; shared-head-tail is a list of (head-id . head-id*) pairs.
+            [shared-head-tail
+             (let ([all-head-ids (apply append head-idss)]
+                   [all-head-ids* (apply append head-idss*)])
+               (for/list ([tid (in-list tail-ids)]
+                          #:when (for/or ([hid (in-list all-head-ids)])
+                                   (bound-identifier=? tid hid)))
+                 ;; find the corresponding head-id and head-id*
+                 (for/or ([hid (in-list all-head-ids)]
+                          [hid* (in-list all-head-ids*)])
+                   (and (bound-identifier=? tid hid)
+                        (cons hid hid*)))))]
             [hid-args (apply append hid-argss)]
             [reps (generate-temporaries (for/list ([head heads]) 'rep))])
        (with-syntax ([x xvar]
@@ -443,16 +511,30 @@
                                 [else
                                  (let ([hid hid-rhs] ... ...
                                        [fail-tail fail])
-                                   #,(compile**
-                                      (cdr vars)
-                                      (list (make-Row rest-pats k
-                                                      (Row-unmatch (car block))
-                                                      (append
-                                                       heads-seen
-                                                       tail-seen
-                                                       (Row-vars-seen
-                                                        (car block)))))
-                                      #'fail-tail))])])
+                                   #,(let ([rest-body
+                                            (compile**
+                                             (cdr vars)
+                                             (list (make-Row rest-pats k
+                                                             (Row-unmatch (car block))
+                                                             (append
+                                                              heads-seen-final
+                                                              tail-seen
+                                                              (Row-vars-seen
+                                                               (car block)))))
+                                             #'fail-tail)])
+                                       ;; Wrap rest-body with equality checks for
+                                       ;; variables shared between head and tail.
+                                       ;; After the let above, hid = collected value.
+                                       ;; hid* (renamed) = tail-matched value.
+                                       (let ([body
+                                              (for/fold ([body rest-body])
+                                                        ([pair (in-list shared-head-tail)])
+                                                (let ([orig-id (car pair)]
+                                                      [renamed-id (cdr pair)])
+                                                  #`(if ((match-equality-test) #,renamed-id #,orig-id)
+                                                         #,body
+                                                         (fail-tail))))])
+                                         body)))])])
            (parameterize ([current-renaming
                            (for/fold ([ht (copy-mapping (current-renaming))])
                                ([id (apply append head-idss)]
@@ -486,7 +568,7 @@
                                       heads-seen
                                       (Row-vars-seen
                                        (car block))))))
-                    #'failkv))))))]
+                    #'failkv))))))])]
     [else (error 'compile "unsupported pattern: ~a\n" first)]))
 
 (define (generate-block esc rhs unmatch)

--- a/racket/collects/racket/match/parse-helper.rkt
+++ b/racket/collects/racket/match/parse-helper.rkt
@@ -58,7 +58,7 @@
   (cond [(and (not (in-splicing?)) ;; when we're inside splicing, rest-pat isn't the rest
               (not min) ;; if we have a count, better generate general code
               (Null? rest-pat)
-              (or (Var? pat) (Dummy? pat)))
+              (Dummy? pat))
          (make-OrderedAnd (list (make-Pred pred?)
                                 (if to-list
                                     (make-App to-list (list pat))


### PR DESCRIPTION
Raise a syntax error for non-linear patterns where a variable is first bound under `...` and later used outside it. Add `PLT_MATCH_STRICT_ELLIPSIS` env var to reject both directions for testing.